### PR TITLE
Fix padding of timezone for Authors

### DIFF
--- a/lib/models/author.js
+++ b/lib/models/author.js
@@ -59,9 +59,9 @@ Author.createFromString = function createFromString(str) {
  */
 Author.createFromPerson = function createFromPerson(person, date) {
     var offset = new Date().getTimezoneOffset();
-    offset = ((offset<0? '+':'-') +
-          pad('' + parseInt(Math.abs(offset/60)), 2) +
-          pad('' + Math.abs(offset%60), 2));
+    offset = ((offset<=0? '+':'-') +
+          pad(2, '' + parseInt(Math.abs(offset/60)), '0') +
+          pad(2, '' + Math.abs(offset%60), '0'));
 
     return new Author({
         name: person.getName(),


### PR DESCRIPTION
The timezones are currently padded using whitespace characters from the right, while they should be padded with `'0'`s from the left.
This PR also fixes the offset sign when offset is 0.